### PR TITLE
Added ability to ignore pods with an annotation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,19 @@ output.log 	 ...................................................................
 output.log 	 ........................................................................................................
 ```
 
+**Ignores**
+
+You may want to ignore some pods. This can be done by adding the following annotation to it.
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    sherlock.nickschuch.github.com/watson-ignore: "true"
+  ...
+```
+
 ## Resources
 
 * [Dave Cheney - Reproducible Builds](https://www.youtube.com/watch?v=c3dW80eO88I)

--- a/cmd/watson.go
+++ b/cmd/watson.go
@@ -73,7 +73,7 @@ func (cmd *cmdWatson) run(c *kingpin.ParseContext) error {
 				}
 
 				if utils.IsIgnored(newPod) {
-					log.Info("Skipping ignored pod %s/%s", newPod.ObjectMeta.Namespace, newPod.ObjectMeta.Name)
+					log.Info(fmt.Sprintf("Skipping ignored pod %s/%s", newPod.ObjectMeta.Namespace, newPod.ObjectMeta.Name))
 				} else {
 					for _, newContainer := range newPod.Status.ContainerStatuses {
 						oldContainer, err := utils.HasRestarts(oldPod.Status.ContainerStatuses, newContainer.Name)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -22,11 +22,8 @@ func HasRestarts(statuses []corev1.ContainerStatus, name string) (corev1.Contain
 
 // IsIgnored checks for the pod annotation which instructs watson to ignore it.
 func IsIgnored(pod *corev1.Pod) bool {
-	for k, _ := range pod.ObjectMeta.Annotations {
-		if k == IgnorePodAnnotation {
-			return true
-		}
+	if _, ok := pod.ObjectMeta.Annotations[IgnorePodAnnotation]; ok {
+		return true
 	}
-
 	return false
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -6,6 +6,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const (
+	IgnorePodAnnotation = "sherlock.nickschuch.github.com/watson-ignore"
+)
+
 func HasRestarts(statuses []corev1.ContainerStatus, name string) (corev1.ContainerStatus, error) {
 	for _, status := range statuses {
 		if status.Name == name {
@@ -19,7 +23,7 @@ func HasRestarts(statuses []corev1.ContainerStatus, name string) (corev1.Contain
 // IsIgnored checks for the pod annotation which instructs watson to ignore it.
 func IsIgnored(pod *corev1.Pod) bool {
 	for k, _ := range pod.ObjectMeta.Annotations {
-		if k == "sherlock.nickschuch.github.com/watson-ignore" {
+		if k == IgnorePodAnnotation {
 			return true
 		}
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -15,3 +15,14 @@ func HasRestarts(statuses []corev1.ContainerStatus, name string) (corev1.Contain
 
 	return corev1.ContainerStatus{}, fmt.Errorf("cannot find container status with name: %s", name)
 }
+
+// IsIgnored checks for the pod annotation which instructs watson to ignore it.
+func IsIgnored(pod *corev1.Pod) bool {
+	for k, _ := range pod.ObjectMeta.Annotations {
+		if k == "sherlock.nickschuch.github.com/watson-ignore" {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
With this change, pods can be ignored by the watson command by adding the following annotation.

```
apiVersion: v1
kind: Pod
metadata:
  annotations:
    sherlock.nickschuch.github.com/watson-ignore: "true"
  ...
```